### PR TITLE
Ability to download Participant Audio Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ﻿.venv
 config.py
 __pycache__
+sample_meeting.json

--- a/config_template.py
+++ b/config_template.py
@@ -32,6 +32,19 @@ RECORDING_FILE_TYPES = [
     # R"SUMMARY",        # Summary file of the recording in JSON file format.
 ]
 
+# Put here the file types you wish to download. If empty, no file type filtering will happen.
+PARTICIPANT_AUDIO_FILE_TYPES = [
+    # R"MP4",            # Video file of the recording.
+    # R"M4A",            # Audio-only file of the recording.
+    # R"TRANSCRIPT",     # Transcription file of the recording in VTT format.
+    # R"CHAT",           # A TXT file containing in-meeting chat messages that were sent during the meeting.
+    # R"CSV",            # File containing polling data in CSV format.
+    # R"SUMMARY",        # Summary file of the recording in JSON file format.
+] 
+
+# If True, recordings will not downloaded.
+IGNORE_PARTICIPANT_AUDIO = False
+
 # If True, recordings will be grouped in folders by their owning user.
 GROUP_BY_USER = True
 

--- a/zoom_batch_downloader.py
+++ b/zoom_batch_downloader.py
@@ -8,6 +8,7 @@ import requests
 from colorama import Fore, Style
 
 import utils
+import urllib.parse
 
 colorama.init()
 
@@ -175,10 +176,29 @@ def get_meetings(user_email, start_date, end_date):
 
 	return meetings
 
+import urllib.parse
+
+def get_meeting(meetingId):
+    # Check if the meetingId starts with / or //
+    if meetingId.startswith('/') or meetingId.startswith('//'):
+        # First encoding
+        encoded_once = urllib.parse.quote(meetingId, safe='')
+        # Second encoding
+        meetingId = urllib.parse.quote(encoded_once, safe='')
+
+    url = f'https://api.zoom.us/v2/meetings/{meetingId}/recordings'
+    response = get_with_token(lambda t: requests.get(url, headers=get_headers(t))).json()
+
+    if response:
+        return response
+    else:
+        raise Exception(f'No meeting found with id: {meetingId}')
+
 def download_recordings_from_meetings(meetings, host_folder):
 	file_count, total_size, skipped_count = 0, 0, 0
 
 	for meeting in meetings:
+
 		if CONFIG.TOPICS and meeting['topic'] not in CONFIG.TOPICS and utils.slugify(meeting['topic']) not in CONFIG.TOPICS:
 			continue
 
@@ -186,6 +206,7 @@ def download_recordings_from_meetings(meetings, host_folder):
 			continue
 		
 		for recording_file in meeting['recording_files']:
+
 			if 'file_size' not in recording_file:
 				continue
 
@@ -205,6 +226,44 @@ def download_recordings_from_meetings(meetings, host_folder):
 				file_count += 1
 			else:
 				skipped_count += 1
+		if CONFIG.IGNORE_PARTICIPANT_AUDIO:
+			continue
+		else:
+			pa_file_count, pa_total_size, pa_skipped_count  = download_participant_audio_files_from_meeting(meeting['uuid'], host_folder)
+			file_count += pa_file_count
+			total_size += pa_total_size
+			skipped_count += pa_skipped_count
+
+	return file_count, total_size, skipped_count
+
+def download_participant_audio_files_from_meeting(meetingId, host_folder):
+	file_count, total_size, skipped_count = 0, 0, 0
+
+	meeting = get_meeting(meetingId)
+
+	if 'participant_audio_files' not in meeting:
+		return file_count, total_size, skipped_count
+	
+	for participant_audio_file in meeting['participant_audio_files']:
+		if 'file_size' not in participant_audio_file:
+			continue
+
+		if CONFIG.PARTICIPANT_AUDIO_FILE_TYPES and participant_audio_file['file_type'] not in CONFIG.PARTICIPANT_AUDIO_FILE_TYPES:
+			continue
+
+		url = participant_audio_file['download_url']
+		topic = utils.slugify(meeting['topic'])
+		ext = utils.slugify(participant_audio_file['file_extension'])
+		recording_name = utils.slugify(f'{topic}__{participant_audio_file["recording_start"]}')
+		file_id = participant_audio_file['id']
+		file_name = utils.slugify(f'{recording_name}__{participant_audio_file["file_name"]}__{file_id[-8:]}') + '.' + ext
+		file_size = int(participant_audio_file.get('file_size'))
+
+		if download_recording_file(url, host_folder, file_name, file_size, topic, recording_name):
+			total_size += file_size
+			file_count += 1
+		else:
+			skipped_count += 1
 	
 	return file_count, total_size, skipped_count
 


### PR DESCRIPTION
Participant Audio Files will automatically downloaded for all meetings.

Setting the `IGNORE_PARTICIPANT_AUDIO` flag to `true` will ignore the participant audio downloads.

The The[ /users/{userId}/recordings](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/recordingsList) endpoint doesn't list the participant audio files. As a result, a new fetch request needs to be made to each meeting at endpoint [/meeting/{meetingId}/recordings](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/recordingGet) to retrieve and download the files.