### PR TITLE
Fixed error on filename concatenation

### DIFF
--- a/zoom_batch_downloader.py
+++ b/zoom_batch_downloader.py
@@ -213,7 +213,7 @@ def download_recordings_from_meetings(meetings, host_folder):
 			ext = recording_file.get('file_extension') or os.path.splitext(recording_file['file_name'])[1]
 			recording_name = utils.slugify(f'{topic}__{recording_file["recording_start"]}')
 			file_id = recording_file['id']
-			file_name_suffix =  os.path.splitext(recording_file['file_name'][0]) + '__' if 'file_name' in recording_file else ''
+			file_name_suffix =  os.path.splitext(recording_file['file_name'])[0] + '__' if 'file_name' in recording_file else ''
 			recording_type_suffix =  recording_file["recording_type"] + '__' if 'recording_type' in recording_file else ''
 			file_name = utils.slugify(
 				f'{recording_name}__{recording_type_suffix}{file_name_suffix}{file_id[-8:]}'


### PR DESCRIPTION
Ran into the following error `Error: can only concatenate tuple (not "str") to tuple` which was resolved by fixing filename concatenation. 

cc @AnessZurba 